### PR TITLE
Add broadcast chat box on home route

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -185,3 +185,15 @@ p { margin: 0; }
 	font-style: italic;	
 	margin: 0 0 0 80px;
 }
+#send-message {
+	margin-left: 8px;
+	padding: 8px 14px;
+	cursor: pointer;
+	background: #293239;
+	color: #fff;
+	border-radius: 3px;
+}
+
+#user-status {
+	align-self: center;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,65 +1,49 @@
-const charBuffer = [];
+$(document).ready(() => {
+  const socket = io();
 
-const KEYCODES = {
-	BACKSPACE: 8,
-	SPACE: 32,
-	DIGIT_0: 48,
-	TILDE: 126,
-	SEMICOLON: 186,
-	FORWARD_SLASH: 191,
-};
+  const appendMessage = (message) => {
+    const messageDate = new Date(message.timestamp);
+    const timeText = Number.isNaN(messageDate.getTime())
+      ? ''
+      : messageDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
-$(document).ready(() =>{
+    $('#chat-history').append(`
+      <div class="chat-message clearfix">
+        <div class="chat-message-content">
+          <span class="chat-time">${timeText}</span>
+          <h5>${message.userId}</h5>
+          <p>${message.text}</p>
+        </div>
+      </div>
+      <hr>
+    `);
 
-	/*************************************************************************/
-	/* Web socket events *****************************************************/
-	const socket = io();
-	socket.on('update', function(data){
-		console.log("data")
-	});
+    const chatHistory = document.getElementById('chat-history');
+    chatHistory.scrollTop = chatHistory.scrollHeight;
+  };
 
-	const updateUserMessages = ()=>{
-		const message = charBuffer.join('');
-		$("#message").val(charBuffer.join(''));
-		$("#title").html(charBuffer.join(''));
-	}
+  $('#chat-form').on('submit', (event) => {
+    event.preventDefault();
+    const text = $('#message').val().toString();
 
-	const process_keycode = (event)=>{
-		if (event.key === 'Backspace') { 
-			const lastChar = charBuffer.pop(); 
-		} else { 
-			charBuffer.push(event.key);
-		}
-		updateUserMessages();
-	}
+    if (!text.trim()) {
+      return;
+    }
 
-	$("#message").keydown((event) => {
-		event.preventDefault();
-		if(	event.keyCode === KEYCODES.SPACE 
-			|| (event.keyCode >= KEYCODES.DIGIT_0 && event.keyCode <= KEYCODES.TILDE)
-			|| (event.keyCode >= KEYCODES.SEMICOLON && event.keyCode <= KEYCODES.FORWARD_SLASH)
-			|| event.keyCode === KEYCODES.BACKSPACE)
-			{
-			process_keycode(event);		
-		}
+    socket.emit('chat message', text);
+    $('#message').val('');
+  });
 
-	});
+  socket.on('chat message', (message) => {
+    appendMessage(message);
+  });
 
-	$("#send-message").on('click', (event)=>{
-		event.preventDefault();
-		socket.emit('chat message', charBuffer.join(''));
-		charBuffer.length = 0;
-		updateUserMessages();
-	});
+  $('#live-chat header').on('click', () => {
+    $('.chat').slideToggle(300, 'swing');
+  });
 
-	$('#live-chat header').on('click', () =>{
-		$('.chat').slideToggle(300, 'swing');
-		$('.chat-message-counter').fadeToggle(300, 'swing');
-	});
-
-	$('.chat-close').on('click', (e) =>{
-		e.preventDefault();
-		$('#live-chat').fadeOut(300);
-	});
-
-}) 
+  $('.chat-close').on('click', (event) => {
+    event.preventDefault();
+    $('#live-chat').fadeOut(300);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,3 @@
-/******************************************************************************
- * The entry point for the llm-deliotte-chat-bot application. 
- * The appliation is a chat bot that is hosted on Azure and is accessible
- * through http or websocket connections. 
- * December 2023
-/******************************************************************************/
-// <----------------------------- 1. Load Environment Variables ---------------->
 import { appFactory } from './server/appFactory';
 import * as path from 'path';
 import {config} from 'dotenv';
@@ -17,22 +10,19 @@ const ENV_FILE_PATH = path.join(__dirname, '..', ENV_FILE_NAME);
 config({ path: ENV_FILE_PATH });
 
 const logger = winston.createLogger({
-    level: 'info',
-    format: winston.format.json(),
-    transports: [
-      new winston.transports.Console({
-        format: winston.format.simple(),
-      }),
-    ],
-  });
-
-interface UpdateMessage {
-  property: string;
-  value: string;
-}
+  level: 'info',
+  format: winston.format.json(),
+  transports: [
+    new winston.transports.Console({
+      format: winston.format.simple(),
+    }),
+  ],
+});
 
 interface ChatMessage {
   text: string;
+  userId: string;
+  timestamp: string;
 }
 
 interface FurryMalsApp {
@@ -40,7 +30,6 @@ interface FurryMalsApp {
 }
 
 const main = async (): Promise<void> => {
-
   const furryMalsApp: FurryMalsApp = await appFactory(logger);
   const io: SocketIOServer = furryMalsApp.io;
 
@@ -48,29 +37,29 @@ const main = async (): Promise<void> => {
     const userId = randomUUID();
     socket.data.user_id = userId;
     socket.emit('user_id', { user_id: userId });
-    console.log(`user connected: ${userId}`);
+    logger.info(`user connected: ${userId}`);
 
-    io.emit('update', { property: "prop", value: "fdsa" } as UpdateMessage);
+    socket.on('chat message', (text: string): void => {
+      const cleanedText = text.trim();
+      if (!cleanedText) {
+        return;
+      }
 
-    socket.on('chat message', (msg: ChatMessage): void => {
-      console.log(msg);
-      io.emit('chat message', msg);
+      const message: ChatMessage = {
+        text: cleanedText,
+        userId,
+        timestamp: new Date().toISOString(),
+      };
+
+      socket.broadcast.emit('chat message', message);
     });
- 
+
     socket.on('disconnect', (): void => {
-      console.log(`user disconnected: ${socket.data.user_id}`);
+      logger.info(`user disconnected: ${socket.data.user_id}`);
     });
-  
-
-  })
-
+  });
 }
 
-
-
-
-main()
-.catch(e => {
-  console.log('error')
-})
-
+main().catch(() => {
+  logger.error('error starting application');
+});

--- a/src/server/appFactory.ts
+++ b/src/server/appFactory.ts
@@ -8,20 +8,18 @@ import winston from 'winston';
 
 export const appFactory = async (logger: winston.Logger): Promise<FurryMallsApp> => {
 
-  /********************************************************/
   const app: Express = express();
   const port = process.env.PORT || 3000;
-  /********************************************************/
-  app.engine('handlebars', engine());
-    app.engine('hbs', engine({
-      extname: 'handlebars',
-      defaultLayout: 'main',
-      layoutsDir: path.join(__dirname, '../views/layouts'),
-      partialsDir: path.join(__dirname, '../views/partials')
-    }));
-    app.set('view engine', 'handlebars');
-    app.use(express.static('public'));
-  /********************************************************/
+
+  app.engine('hbs', engine({
+    extname: 'handlebars',
+    defaultLayout: 'main',
+    layoutsDir: path.join(__dirname, '../views/layouts'),
+    partialsDir: path.join(__dirname, '../views/partials')
+  }));
+  app.set('view engine', 'hbs');
+  app.set('views', path.join(__dirname, '../views'));
+  app.use(express.static('public'));
 
   app.get('/', (req, res) => {
     res.render('home');
@@ -35,12 +33,13 @@ export const appFactory = async (logger: winston.Logger): Promise<FurryMallsApp>
   httpServer.listen(port, () => {
     logger.info(`Server running at http://localhost:${port}`);
   });
+
   const io = new SocketIOServer(httpServer);
 
   return {
     io,
-    app, 
-    httpServer, 
+    app,
+    httpServer,
 
     shutDown: async ()=>{
       io.close(()=>{

--- a/src/server/appFactory.ts
+++ b/src/server/appFactory.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import fs from 'node:fs';
 import express, {Express} from 'express';
 import {createServer} from 'node:http';
 import {engine} from 'express-handlebars';
@@ -6,20 +7,41 @@ import {Server as SocketIOServer} from "socket.io";
 import {FurryMallsApp} from './types';
 import winston from 'winston';
 
-export const appFactory = async (logger: winston.Logger): Promise<FurryMallsApp> => {
+const resolveFirstExistingPath = (paths: string[]): string => {
+  for (const possiblePath of paths) {
+    if (fs.existsSync(possiblePath)) {
+      return possiblePath;
+    }
+  }
 
+  return paths[0];
+};
+
+export const appFactory = async (logger: winston.Logger): Promise<FurryMallsApp> => {
   const app: Express = express();
   const port = process.env.PORT || 3000;
 
-  app.engine('hbs', engine({
-    extname: 'handlebars',
+  const viewsDir = resolveFirstExistingPath([
+    path.join(process.cwd(), 'src/views'),
+    path.join(process.cwd(), 'dist/views'),
+    path.join(__dirname, '../views'),
+  ]);
+
+  const publicDir = resolveFirstExistingPath([
+    path.join(process.cwd(), 'public'),
+    path.join(__dirname, '../../public'),
+  ]);
+
+  app.engine('handlebars', engine({
+    extname: '.handlebars',
     defaultLayout: 'main',
-    layoutsDir: path.join(__dirname, '../views/layouts'),
-    partialsDir: path.join(__dirname, '../views/partials')
+    layoutsDir: path.join(viewsDir, 'layouts'),
+    partialsDir: path.join(viewsDir, 'partials')
   }));
-  app.set('view engine', 'hbs');
-  app.set('views', path.join(__dirname, '../views'));
-  app.use(express.static('public'));
+
+  app.set('view engine', 'handlebars');
+  app.set('views', viewsDir);
+  app.use(express.static(publicDir));
 
   app.get('/', (req, res) => {
     res.render('home');

--- a/src/server/appFactory.ts
+++ b/src/server/appFactory.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import fs from 'node:fs';
 import express, {Express} from 'express';
 import {createServer} from 'node:http';
 import {engine} from 'express-handlebars';
@@ -6,12 +7,29 @@ import {Server as SocketIOServer} from "socket.io";
 import {FurryMallsApp} from './types';
 import winston from 'winston';
 
-export const appFactory = async (logger: winston.Logger): Promise<FurryMallsApp> => {
+const resolveFirstExistingPath = (paths: string[]): string => {
+  for (const possiblePath of paths) {
+    if (fs.existsSync(possiblePath)) {
+      return possiblePath;
+    }
+  }
 
+  return paths[0];
+};
+
+export const appFactory = async (logger: winston.Logger): Promise<FurryMallsApp> => {
   const app: Express = express();
   const port = process.env.PORT || 3000;
-  const viewsDir = path.resolve(__dirname, '../../views');
-  const publicDir = path.resolve(__dirname, '../../public');
+  const viewsDir = resolveFirstExistingPath([
+    path.join(process.cwd(), 'views'),
+    path.join(process.cwd(), 'dist/views'),
+    path.resolve(__dirname, '../../views'),
+  ]);
+
+  const publicDir = resolveFirstExistingPath([
+    path.join(process.cwd(), 'public'),
+    path.resolve(__dirname, '../../public'),
+  ]);
 
   app.engine('handlebars', engine({
     extname: '.handlebars',

--- a/src/server/appFactory.ts
+++ b/src/server/appFactory.ts
@@ -10,16 +10,18 @@ export const appFactory = async (logger: winston.Logger): Promise<FurryMallsApp>
 
   const app: Express = express();
   const port = process.env.PORT || 3000;
+  const viewsDir = path.resolve(__dirname, '../../views');
+  const publicDir = path.resolve(__dirname, '../../public');
 
-  app.engine('hbs', engine({
-    extname: 'handlebars',
+  app.engine('handlebars', engine({
+    extname: '.handlebars',
     defaultLayout: 'main',
-    layoutsDir: path.join(__dirname, '../views/layouts'),
-    partialsDir: path.join(__dirname, '../views/partials')
+    layoutsDir: path.join(viewsDir, 'layouts'),
+    partialsDir: path.join(viewsDir, 'partials')
   }));
-  app.set('view engine', 'hbs');
-  app.set('views', path.join(__dirname, '../views'));
-  app.use(express.static('public'));
+  app.set('view engine', 'handlebars');
+  app.set('views', viewsDir);
+  app.use(express.static(publicDir));
 
   app.get('/', (req, res) => {
     res.render('home');

--- a/src/views/home.handlebars
+++ b/src/views/home.handlebars
@@ -1,0 +1,22 @@
+<nav>
+  <h3>Fantastic Furrymals</h3>
+  <span id="user-status">Connected</span>
+</nav>
+
+<div id="live-chat">
+  <header class="clearfix">
+    <a href="#" class="chat-close">x</a>
+    <h4>Global Chat</h4>
+  </header>
+
+  <div class="chat">
+    <div class="chat-history" id="chat-history"></div>
+
+    <form id="chat-form">
+      <fieldset>
+        <input id="message" type="text" placeholder="Type your message..." autocomplete="off" maxlength="300" />
+        <button id="send-message" type="submit">Send</button>
+      </fieldset>
+    </form>
+  </div>
+</div>

--- a/src/views/layouts/main.handlebars
+++ b/src/views/layouts/main.handlebars
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fantastic Furrymals Chat</title>
+  <link rel="stylesheet" href="/css/styles.css" />
+</head>
+<body>
+  {{{body}}}
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+  <script src="/js/main.js"></script>
+</body>
+</html>

--- a/src/views/workspace.handlebars
+++ b/src/views/workspace.handlebars
@@ -1,0 +1,2 @@
+<h1>Workspace</h1>
+<p>{{data}}</p>

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -7,7 +7,7 @@
 		</header>
 
 		<div class="chat">
-			<div class="chat-history">
+			<div class="chat-history" id="chat-history">
 				<div class="chat-message clearfix">
 				</div> <!-- end chat-message -->
 				<hr>
@@ -20,10 +20,10 @@
 			</div> <!-- end chat-history -->
 
 
-			<form action="#" method="post">
+			<form id="chat-form" action="#" method="post">
 				<fieldset>
 					<input type="text" id="message" placeholder="type here" autofocus>
-					<button id="send-message">Send</button>	
+					<button id="send-message" type="submit">Send</button>	
 				</fieldset>
 
 			</form>


### PR DESCRIPTION
### Motivation
- Provide a global realtime chat UI on the root (`/`) route so every connected client sees a chat box and messages are broadcast to other clients. 
- Replace the previous ad-hoc client behavior with a simple submit/listen flow so messages are reliably propagated and rendered across connections.

### Description
- Updated server Socket.IO handling in `src/main.ts` to accept raw chat text, validate/trim it, stamp messages with `userId` and `timestamp`, and broadcast to other clients using `socket.broadcast.emit`.
- Configured Express/Handlebars in `src/server/appFactory.ts` to set the `views` path and `hbs` engine so `/` renders a Handlebars view; kept `/workspace` intact and returned `io`, `app`, and `httpServer` from `appFactory`.
- Added view/layout files `src/views/layouts/main.handlebars`, `src/views/home.handlebars`, and `src/views/workspace.handlebars` to render the chat UI on the home page and include the client script and Socket.IO client bundle.
- Reworked client code in `public/js/main.js` to submit chat messages via a form, render incoming messages with timestamps into `#chat-history`, and added small UI styles in `public/css/styles.css` for the send button and status label.

### Testing
- Ran `npm test` which failed due to missing dev tooling (`nyc` not available) in this environment and a blocked dependency install resulting in `sh: 1: nyc: not found`.
- Attempted `npm install` and the install failed with `npm error 403` from the registry preventing dependency installation, so test dependencies could not be installed.
- Attempted `npm run build` which failed for the same reason because `rimraf` and other build dependencies are not installed.
- No automated tests passed in this environment due to the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9b9e469c8332a648a819dd140961)