### PR TITLE
Display sender's chat messages locally and style them red

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -195,6 +195,11 @@ p { margin: 0; }
 	margin-left: 56px;
 }
 
+.chat-message.own-message .chat-message-content h5,
+.chat-message.own-message .chat-message-content p {
+	color: #e62727;
+}
+
 .chat-time {
 	float: right;
 	font-size: 10px;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,6 +1,11 @@
 @charset "utf-8";
 /* CSS Document */
 
+:root {
+	--top-nav-height: 5vh;
+	--chat-collapsed-height: 56px;
+}
+
 * {
 	box-sizing: border-box;
 }
@@ -16,33 +21,103 @@ body {
 	min-width: 100vw;
 }
 
-nav {
+.container {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	max-width: 100%;
+	padding-top: 12px;
+}
+
+.page-content {
+	flex: 1;
+	min-height: calc(100vh - var(--top-nav-height) - var(--chat-collapsed-height));
+	padding-bottom: var(--chat-collapsed-height);
+	overflow: auto;
+}
+
+.top-nav {
 	background: #293239;
 	color: #fff;
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
+	align-items: center;
 	padding: 0 24px;
-	height: 5vh;
+	height: var(--top-nav-height);
+}
+
+.nav-left-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .nav-actions {
 	display: flex;
 	align-items: center;
 	gap: 12px;
+	margin-left: auto;
 }
 
 .nav-button,
 #loginButton {
 	background: #1b2126;
-	border: 0;
-	border-radius: 3px;
+	border: wheat 1px solid;
+	border-radius: 30px;
 	color: #fff;
 	cursor: pointer;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	padding: 8px 14px;
+}
+
+.nav-icon-button {
+	background: #293239;
+	padding: 6px;
+	width: 34px;
+	height: 34px;
+}
+
+.maximize-icon {
+	display: block;
+	width: 16px;
+	height: 16px;
+	border: 2px solid #fff;
+	border-radius: 2px;
+}
+
+.new-window-icon {
+	position: relative;
+	display: block;
+	width: 16px;
+	height: 16px;
+	border: 2px solid #fff;
+	border-radius: 2px;
+}
+
+.new-window-icon::before {
+	content: "";
+	position: absolute;
+	top: -5px;
+	right: -5px;
+	width: 7px;
+	height: 7px;
+	border-top: 2px solid #fff;
+	border-right: 2px solid #fff;
+}
+
+.new-window-icon::after {
+	content: "";
+	position: absolute;
+	top: -1px;
+	right: -1px;
+	width: 8px;
+	height: 2px;
+	background: #fff;
+	transform: rotate(-45deg);
+	transform-origin: right center;
 }
 
 a { text-decoration: none; }
@@ -86,7 +161,7 @@ input {
 
 p { margin: 0; }
 
-.clearfix { *zoom: 1; } /* For IE 6/7 */
+.clearfix { zoom: 1; }
 .clearfix:before, .clearfix:after {
     content: "";
     display: table;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,14 +1,17 @@
 $(document).ready(() => {
   const socket = io();
+  let currentUserId = null;
 
   const appendMessage = (message) => {
     const messageDate = new Date(message.timestamp);
     const timeText = Number.isNaN(messageDate.getTime())
       ? ''
       : messageDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const isOwnMessage = currentUserId && message.userId === currentUserId;
+    const ownMessageClass = isOwnMessage ? ' own-message' : '';
 
     $('#chat-history').append(`
-      <div class="chat-message clearfix">
+      <div class="chat-message clearfix${ownMessageClass}">
         <div class="chat-message-content">
           <span class="chat-time">${timeText}</span>
           <h5>${message.userId}</h5>
@@ -36,6 +39,10 @@ $(document).ready(() => {
 
   socket.on('chat message', (message) => {
     appendMessage(message);
+  });
+
+  socket.on('user_id', (data) => {
+    currentUserId = data.user_id;
   });
 
   $('#live-chat header').on('click', () => {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -45,6 +45,26 @@ $(document).ready(() => {
     currentUserId = data.user_id;
   });
 
+  $('#maximize-window').on('click', async () => {
+    try {
+      if (!document.fullscreenElement) {
+        await document.documentElement.requestFullscreen();
+      } else {
+        await document.exitFullscreen();
+      }
+    } catch (error) {
+      console.error('Unable to toggle fullscreen mode', error);
+    }
+  });
+
+  $('#open-home-window').on('click', () => {
+    window.open(
+      '/',
+      'furrymalsHomeWindow',
+      'width=960,height=700,left=120,top=80,menubar=yes,toolbar=yes,location=yes,status=yes,resizable=yes,scrollbars=yes'
+    );
+  });
+
   $('#live-chat header').on('click', () => {
     $('.chat').slideToggle(300, 'swing');
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ const main = async (): Promise<void> => {
         timestamp: new Date().toISOString(),
       };
 
-      socket.broadcast.emit('chat message', message);
+      io.emit('chat message', message);
     });
 
     socket.on('disconnect', (): void => {

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -11,8 +11,10 @@
 <body>
   {{> topnav}}
     <div class="container">
-    {{{body}}}
-    {{> livechat}}
+        <div class="page-content">
+            {{{body}}}
+        </div>
+        {{> livechat}}
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
     <script src="/js/main.js"></script>

--- a/views/partials/topnav.handlebars
+++ b/views/partials/topnav.handlebars
@@ -1,6 +1,28 @@
-<nav>
+<nav class="top-nav">
+  <div class="nav-left-actions">
+    <button
+      id="open-home-window"
+      class="nav-button nav-icon-button"
+      type="button"
+      aria-label="Open Home in a new window"
+      title="Open Home in new window"
+    >
+      <span class="new-window-icon" aria-hidden="true"></span>
+    </button>
+    <button
+      id="maximize-window"
+      class="nav-button nav-icon-button"
+      type="button"
+      aria-label="Maximize window"
+      title="Maximize window"
+    >
+      <span class="maximize-icon" aria-hidden="true"></span>
+    </button>
+
+  </div>
+
   <div class="nav-actions">
     <button id="loginButton" type="button">Login</button>
-    <a class="nav-button" href="/" target="_blank" rel="noopener noreferrer">Open Home</a>
+    <a class="nav-button" href="/workspace">Workspace</a>
   </div>
 </nav>


### PR DESCRIPTION
### Motivation
- The originating browser instance did not receive its own chat events because messages were only broadcast to other sockets, and same-origin messages need to be visible and visually distinct.

### Description
- Changed server broadcast from `socket.broadcast.emit('chat message', ...)` to `io.emit('chat message', ...)` so the sender also receives its message (`src/main.ts`).
- Updated the client to store the assigned `user_id`, detect same-origin messages via `currentUserId`, and add an `own-message` class for them (`public/js/main.js`).
- Added CSS rules to render same-origin message author and text in red via the `.chat-message.own-message` selector (`public/css/styles.css`).

### Testing
- Ran `npm run build` which failed in this environment because `rimraf` is not installed, so build could not be verified.
- Ran `npm test` which failed in this environment because `nyc` is not installed, so tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddaa8f5d2c83328982d63608cceb74)