### PR TITLE
Add structured session events with 3D editor and workspace DataTable

### DIFF
--- a/public/js/home-events.js
+++ b/public/js/home-events.js
@@ -1,4 +1,8 @@
-$(document).ready(() => {
+document.addEventListener('DOMContentLoaded', () => {
+  const $ = window.jQuery;
+  if (!$) {
+    return;
+  }
   const eventList = $('#event-list');
   const canvasHost = document.getElementById('events-canvas');
   const modalElement = document.getElementById('eventDetailModal');

--- a/public/js/home-events.js
+++ b/public/js/home-events.js
@@ -1,0 +1,176 @@
+$(document).ready(() => {
+  const eventList = $('#event-list');
+  const canvasHost = document.getElementById('events-canvas');
+  const modalElement = document.getElementById('eventDetailModal');
+
+  if (!canvasHost || !window.THREE || !Array.isArray(window.sessionEvents)) {
+    return;
+  }
+
+  const formatDate = (date) => {
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) {
+      return '';
+    }
+
+    return parsed.toLocaleString();
+  };
+
+  const renderEventList = () => {
+    eventList.empty();
+    window.sessionEvents.forEach((eventItem) => {
+      eventList.append(`<li><strong>${eventItem.event_id}</strong> — ${eventItem.title}</li>`);
+    });
+  };
+
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color('#0f172a');
+
+  const camera = new THREE.PerspectiveCamera(55, canvasHost.clientWidth / 420, 0.1, 1000);
+  camera.position.z = 13;
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(canvasHost.clientWidth, 420);
+  canvasHost.appendChild(renderer.domElement);
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.8);
+  scene.add(ambient);
+  const directional = new THREE.DirectionalLight(0xffffff, 0.9);
+  directional.position.set(0, 8, 10);
+  scene.add(directional);
+
+  const raycaster = new THREE.Raycaster();
+  const pointer = new THREE.Vector2();
+  const eventMeshes = [];
+
+  const severityColor = {
+    low: 0x10b981,
+    medium: 0xf59e0b,
+    high: 0xef4444,
+    critical: 0xdc2626,
+  };
+
+  const rebuildMeshes = () => {
+    eventMeshes.forEach(({ mesh }) => scene.remove(mesh));
+    eventMeshes.length = 0;
+
+    window.sessionEvents.forEach((eventItem, idx) => {
+      const geometry = new THREE.SphereGeometry(0.75, 24, 24);
+      const material = new THREE.MeshStandardMaterial({
+        color: severityColor[eventItem.severity] ?? 0x3b82f6,
+      });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.x = (idx - 1) * 3.4;
+      mesh.userData.eventId = eventItem.event_id;
+      scene.add(mesh);
+      eventMeshes.push({ mesh, eventItem });
+    });
+
+    renderEventList();
+  };
+
+  const animate = () => {
+    requestAnimationFrame(animate);
+    eventMeshes.forEach(({ mesh }, idx) => {
+      mesh.rotation.y += 0.01;
+      mesh.position.y = Math.sin(Date.now() / 700 + idx) * 0.6;
+    });
+    renderer.render(scene, camera);
+  };
+
+  const getIntersectedMesh = (clientX, clientY) => {
+    const rect = renderer.domElement.getBoundingClientRect();
+    pointer.x = ((clientX - rect.left) / rect.width) * 2 - 1;
+    pointer.y = -((clientY - rect.top) / rect.height) * 2 + 1;
+
+    raycaster.setFromCamera(pointer, camera);
+    const intersects = raycaster.intersectObjects(eventMeshes.map(({ mesh }) => mesh));
+
+    if (!intersects.length) {
+      return null;
+    }
+
+    return eventMeshes.find(({ mesh }) => mesh === intersects[0].object) ?? null;
+  };
+
+  const fillFormFromEvent = (eventItem) => {
+    $('#event_id').val(eventItem.event_id);
+    $('#title').val(eventItem.title);
+    $('#summary').val(eventItem.summary);
+    $('#description').val(eventItem.description);
+    $('#status').val(eventItem.status);
+    $('#severity').val(eventItem.severity);
+    $('#first_seen').val(new Date(eventItem.first_seen).toISOString().slice(0, 16));
+    $('#last_seen').val(new Date(eventItem.last_seen).toISOString().slice(0, 16));
+    $('#created_at').val(formatDate(eventItem.created_at));
+    $('#updated_at').val(formatDate(eventItem.updated_at));
+  };
+
+  renderer.domElement.addEventListener('wheel', (event) => {
+    event.preventDefault();
+    camera.position.z = Math.max(5, Math.min(30, camera.position.z + event.deltaY * 0.01));
+  });
+
+  renderer.domElement.addEventListener('dblclick', (event) => {
+    const selected = getIntersectedMesh(event.clientX, event.clientY);
+    if (!selected) {
+      return;
+    }
+
+    fillFormFromEvent(selected.eventItem);
+    const modal = bootstrap.Modal.getOrCreateInstance(modalElement);
+    modal.show();
+  });
+
+  renderer.domElement.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+    const selected = getIntersectedMesh(event.clientX, event.clientY);
+    if (!selected) {
+      return;
+    }
+
+    window.sessionEvents = window.sessionEvents.filter(
+      (eventItem) => eventItem.event_id !== selected.eventItem.event_id
+    );
+    rebuildMeshes();
+  });
+
+  $('#event-form').on('submit', (submitEvent) => {
+    submitEvent.preventDefault();
+
+    const selectedId = $('#event_id').val().toString();
+    const selectedIndex = window.sessionEvents.findIndex((eventItem) => eventItem.event_id === selectedId);
+    if (selectedIndex < 0) {
+      return;
+    }
+
+    const updatedEvent = new window.SessionEvent({
+      event_id: selectedId,
+      title: $('#title').val().toString(),
+      summary: $('#summary').val().toString(),
+      description: $('#description').val().toString(),
+      status: $('#status').val().toString(),
+      severity: $('#severity').val().toString(),
+      first_seen: $('#first_seen').val().toString(),
+      last_seen: $('#last_seen').val().toString(),
+      created_at: window.sessionEvents[selectedIndex].created_at,
+      updated_at: new Date().toISOString(),
+    });
+
+    window.sessionEvents.splice(selectedIndex, 1, updatedEvent);
+    rebuildMeshes();
+
+    const modal = bootstrap.Modal.getOrCreateInstance(modalElement);
+    modal.hide();
+  });
+
+  window.addEventListener('resize', () => {
+    const width = canvasHost.clientWidth;
+    camera.aspect = width / 420;
+    camera.updateProjectionMatrix();
+    renderer.setSize(width, 420);
+  });
+
+  rebuildMeshes();
+  animate();
+});

--- a/public/js/home-events.js
+++ b/public/js/home-events.js
@@ -1,40 +1,47 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const $ = window.jQuery;
-  if (!$) {
-    return;
-  }
-  const eventList = $('#event-list');
   const canvasHost = document.getElementById('events-canvas');
   const modalElement = document.getElementById('eventDetailModal');
+  const eventList = document.getElementById('event-list');
+  const form = document.getElementById('event-form');
 
-  if (!canvasHost || !window.THREE || !Array.isArray(window.sessionEvents)) {
+  if (!canvasHost || !modalElement || !eventList || !form || !window.THREE || !Array.isArray(window.sessionEvents)) {
     return;
   }
 
   const formatDate = (date) => {
     const parsed = new Date(date);
-    if (Number.isNaN(parsed.getTime())) {
-      return '';
-    }
+    return Number.isNaN(parsed.getTime()) ? '' : parsed.toLocaleString();
+  };
 
-    return parsed.toLocaleString();
+  const setValue = (id, value) => {
+    const input = document.getElementById(id);
+    if (input) {
+      input.value = value;
+    }
+  };
+
+  const getValue = (id) => {
+    const input = document.getElementById(id);
+    return input ? input.value.toString() : '';
   };
 
   const renderEventList = () => {
-    eventList.empty();
+    eventList.innerHTML = '';
     window.sessionEvents.forEach((eventItem) => {
-      eventList.append(`<li><strong>${eventItem.event_id}</strong> — ${eventItem.title}</li>`);
+      const listItem = document.createElement('li');
+      listItem.innerHTML = `<strong>${eventItem.event_id}</strong> — ${eventItem.title}`;
+      eventList.appendChild(listItem);
     });
   };
 
   const scene = new THREE.Scene();
   scene.background = new THREE.Color('#0f172a');
 
-  const camera = new THREE.PerspectiveCamera(55, canvasHost.clientWidth / 420, 0.1, 1000);
+  const camera = new THREE.PerspectiveCamera(55, Math.max(canvasHost.clientWidth, 300) / 420, 0.1, 1000);
   camera.position.z = 13;
 
   const renderer = new THREE.WebGLRenderer({ antialias: true });
-  renderer.setSize(canvasHost.clientWidth, 420);
+  renderer.setSize(Math.max(canvasHost.clientWidth, 300), 420);
   canvasHost.appendChild(renderer.domElement);
 
   const ambient = new THREE.AmbientLight(0xffffff, 0.8);
@@ -64,8 +71,7 @@ document.addEventListener('DOMContentLoaded', () => {
         color: severityColor[eventItem.severity] ?? 0x3b82f6,
       });
       const mesh = new THREE.Mesh(geometry, material);
-      mesh.position.x = (idx - 1) * 3.4;
-      mesh.userData.eventId = eventItem.event_id;
+      mesh.position.x = (idx - (window.sessionEvents.length - 1) / 2) * 3.4;
       scene.add(mesh);
       eventMeshes.push({ mesh, eventItem });
     });
@@ -89,7 +95,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     raycaster.setFromCamera(pointer, camera);
     const intersects = raycaster.intersectObjects(eventMeshes.map(({ mesh }) => mesh));
-
     if (!intersects.length) {
       return null;
     }
@@ -98,16 +103,16 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const fillFormFromEvent = (eventItem) => {
-    $('#event_id').val(eventItem.event_id);
-    $('#title').val(eventItem.title);
-    $('#summary').val(eventItem.summary);
-    $('#description').val(eventItem.description);
-    $('#status').val(eventItem.status);
-    $('#severity').val(eventItem.severity);
-    $('#first_seen').val(new Date(eventItem.first_seen).toISOString().slice(0, 16));
-    $('#last_seen').val(new Date(eventItem.last_seen).toISOString().slice(0, 16));
-    $('#created_at').val(formatDate(eventItem.created_at));
-    $('#updated_at').val(formatDate(eventItem.updated_at));
+    setValue('event_id', eventItem.event_id);
+    setValue('title', eventItem.title);
+    setValue('summary', eventItem.summary);
+    setValue('description', eventItem.description);
+    setValue('status', eventItem.status);
+    setValue('severity', eventItem.severity);
+    setValue('first_seen', new Date(eventItem.first_seen).toISOString().slice(0, 16));
+    setValue('last_seen', new Date(eventItem.last_seen).toISOString().slice(0, 16));
+    setValue('created_at', formatDate(eventItem.created_at));
+    setValue('updated_at', formatDate(eventItem.updated_at));
   };
 
   renderer.domElement.addEventListener('wheel', (event) => {
@@ -139,10 +144,10 @@ document.addEventListener('DOMContentLoaded', () => {
     rebuildMeshes();
   });
 
-  $('#event-form').on('submit', (submitEvent) => {
+  form.addEventListener('submit', (submitEvent) => {
     submitEvent.preventDefault();
 
-    const selectedId = $('#event_id').val().toString();
+    const selectedId = getValue('event_id');
     const selectedIndex = window.sessionEvents.findIndex((eventItem) => eventItem.event_id === selectedId);
     if (selectedIndex < 0) {
       return;
@@ -150,13 +155,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const updatedEvent = new window.SessionEvent({
       event_id: selectedId,
-      title: $('#title').val().toString(),
-      summary: $('#summary').val().toString(),
-      description: $('#description').val().toString(),
-      status: $('#status').val().toString(),
-      severity: $('#severity').val().toString(),
-      first_seen: $('#first_seen').val().toString(),
-      last_seen: $('#last_seen').val().toString(),
+      title: getValue('title'),
+      summary: getValue('summary'),
+      description: getValue('description'),
+      status: getValue('status'),
+      severity: getValue('severity'),
+      first_seen: getValue('first_seen'),
+      last_seen: getValue('last_seen'),
       created_at: window.sessionEvents[selectedIndex].created_at,
       updated_at: new Date().toISOString(),
     });
@@ -169,7 +174,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   window.addEventListener('resize', () => {
-    const width = canvasHost.clientWidth;
+    const width = Math.max(canvasHost.clientWidth, 300);
     camera.aspect = width / 420;
     camera.updateProjectionMatrix();
     renderer.setSize(width, 420);

--- a/public/js/session.js
+++ b/public/js/session.js
@@ -1,0 +1,69 @@
+(() => {
+  class SessionEvent {
+    constructor({
+      event_id,
+      title,
+      summary,
+      description,
+      status,
+      first_seen,
+      last_seen,
+      created_at,
+      updated_at,
+      severity,
+    }) {
+      this.event_id = event_id;
+      this.title = title;
+      this.summary = summary;
+      this.description = description;
+      this.status = status;
+      this.first_seen = new Date(first_seen);
+      this.last_seen = new Date(last_seen);
+      this.created_at = new Date(created_at);
+      this.updated_at = new Date(updated_at);
+      this.severity = severity;
+    }
+  }
+
+  const events = [
+    new SessionEvent({
+      event_id: 'evt-1001',
+      title: 'Unauthorized login burst',
+      summary: 'Multiple failed SSH attempts from one source.',
+      description: 'A sudden burst of failed SSH logins was observed from IP 203.0.113.16.',
+      status: 'active',
+      first_seen: '2026-04-10T07:15:00.000Z',
+      last_seen: '2026-04-14T08:24:00.000Z',
+      created_at: '2026-04-10T07:15:00.000Z',
+      updated_at: '2026-04-14T08:24:00.000Z',
+      severity: 'high',
+    }),
+    new SessionEvent({
+      event_id: 'evt-1002',
+      title: 'Endpoint malware quarantine',
+      summary: 'EDR quarantined suspicious executable.',
+      description: 'Endpoint protection quarantined a newly dropped binary on host LAB-14.',
+      status: 'monitoring',
+      first_seen: '2026-04-12T10:32:00.000Z',
+      last_seen: '2026-04-14T05:10:00.000Z',
+      created_at: '2026-04-12T10:32:00.000Z',
+      updated_at: '2026-04-14T05:10:00.000Z',
+      severity: 'critical',
+    }),
+    new SessionEvent({
+      event_id: 'evt-1003',
+      title: 'Firewall policy mismatch',
+      summary: 'Unexpected rule ordering after deployment.',
+      description: 'A production firewall policy update changed rule precedence unexpectedly.',
+      status: 'resolved',
+      first_seen: '2026-04-09T18:05:00.000Z',
+      last_seen: '2026-04-13T21:45:00.000Z',
+      created_at: '2026-04-09T18:05:00.000Z',
+      updated_at: '2026-04-13T21:45:00.000Z',
+      severity: 'medium',
+    }),
+  ];
+
+  window.SessionEvent = SessionEvent;
+  window.sessionEvents = events;
+})();

--- a/public/js/workspace-events.js
+++ b/public/js/workspace-events.js
@@ -1,4 +1,8 @@
-$(document).ready(() => {
+document.addEventListener('DOMContentLoaded', () => {
+  const $ = window.jQuery;
+  if (!$ || !$.fn.DataTable) {
+    return;
+  }
   if (!Array.isArray(window.sessionEvents)) {
     return;
   }

--- a/public/js/workspace-events.js
+++ b/public/js/workspace-events.js
@@ -1,0 +1,33 @@
+$(document).ready(() => {
+  if (!Array.isArray(window.sessionEvents)) {
+    return;
+  }
+
+  const tableBody = $('#events-table tbody');
+
+  const formatDate = (value) => {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? '' : date.toLocaleString();
+  };
+
+  window.sessionEvents.forEach((eventItem) => {
+    tableBody.append(`
+      <tr>
+        <td>${eventItem.event_id}</td>
+        <td>${eventItem.title}</td>
+        <td>${eventItem.summary}</td>
+        <td>${eventItem.status}</td>
+        <td>${eventItem.severity}</td>
+        <td>${formatDate(eventItem.first_seen)}</td>
+        <td>${formatDate(eventItem.last_seen)}</td>
+        <td>${formatDate(eventItem.created_at)}</td>
+        <td>${formatDate(eventItem.updated_at)}</td>
+      </tr>
+    `);
+  });
+
+  $('#events-table').DataTable({
+    pageLength: 5,
+    order: [[5, 'desc']],
+  });
+});

--- a/public/js/workspace-events.js
+++ b/public/js/workspace-events.js
@@ -1,13 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const $ = window.jQuery;
-  if (!$ || !$.fn.DataTable) {
-    return;
-  }
   if (!Array.isArray(window.sessionEvents)) {
     return;
   }
 
-  const tableBody = $('#events-table tbody');
+  const tableBody = document.querySelector('#events-table tbody');
+  if (!tableBody) {
+    return;
+  }
 
   const formatDate = (value) => {
     const date = new Date(value);
@@ -15,23 +14,27 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   window.sessionEvents.forEach((eventItem) => {
-    tableBody.append(`
-      <tr>
-        <td>${eventItem.event_id}</td>
-        <td>${eventItem.title}</td>
-        <td>${eventItem.summary}</td>
-        <td>${eventItem.status}</td>
-        <td>${eventItem.severity}</td>
-        <td>${formatDate(eventItem.first_seen)}</td>
-        <td>${formatDate(eventItem.last_seen)}</td>
-        <td>${formatDate(eventItem.created_at)}</td>
-        <td>${formatDate(eventItem.updated_at)}</td>
-      </tr>
-    `);
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${eventItem.event_id}</td>
+      <td>${eventItem.title}</td>
+      <td>${eventItem.summary}</td>
+      <td>${eventItem.status}</td>
+      <td>${eventItem.severity}</td>
+      <td>${formatDate(eventItem.first_seen)}</td>
+      <td>${formatDate(eventItem.last_seen)}</td>
+      <td>${formatDate(eventItem.created_at)}</td>
+      <td>${formatDate(eventItem.updated_at)}</td>
+    `;
+    tableBody.appendChild(row);
   });
 
-  $('#events-table').DataTable({
-    pageLength: 5,
-    order: [[5, 'desc']],
-  });
+  if (window.DataTable) {
+    // DataTables v2 (vanilla)
+    // eslint-disable-next-line no-new
+    new DataTable('#events-table', {
+      pageLength: 5,
+      order: [[5, 'desc']],
+    });
+  }
 });

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -69,6 +69,6 @@
   </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.min.js"></script>
-<script src="/js/session.js"></script>
-<script src="/js/home-events.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.min.js"></script>
+<script defer src="/js/session.js"></script>
+<script defer src="/js/home-events.js"></script>

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -1,1 +1,74 @@
+<h1 class="mb-3">Session Event Graph</h1>
+<p class="text-muted">Use scroll to zoom, double-click an event to edit, and right-click an event to delete.</p>
 
+<div id="events-canvas" class="border rounded bg-dark-subtle mb-3"></div>
+
+<div class="card">
+  <div class="card-header">Active session events</div>
+  <div class="card-body">
+    <ul id="event-list" class="mb-0"></ul>
+  </div>
+</div>
+
+<div class="modal fade" id="eventDetailModal" tabindex="-1" aria-labelledby="eventDetailLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="eventDetailLabel">Event details</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form id="event-form">
+        <div class="modal-body row g-3">
+          <div class="col-md-6">
+            <label class="form-label" for="event_id">Event ID</label>
+            <input class="form-control" id="event_id" readonly>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" for="status">Status</label>
+            <input class="form-control" id="status" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" for="title">Title</label>
+            <input class="form-control" id="title" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" for="severity">Severity</label>
+            <input class="form-control" id="severity" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label" for="summary">Summary</label>
+            <input class="form-control" id="summary" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label" for="description">Description</label>
+            <textarea class="form-control" id="description" rows="3" required></textarea>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" for="first_seen">First seen</label>
+            <input type="datetime-local" class="form-control" id="first_seen" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" for="last_seen">Last seen</label>
+            <input type="datetime-local" class="form-control" id="last_seen" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" for="created_at">Created at</label>
+            <input class="form-control" id="created_at" readonly>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label" for="updated_at">Updated at</label>
+            <input class="form-control" id="updated_at" readonly>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Save changes</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.min.js"></script>
+<script src="/js/session.js"></script>
+<script src="/js/home-events.js"></script>

--- a/views/workspace.handlebars
+++ b/views/workspace.handlebars
@@ -1,1 +1,23 @@
-<h1>Workspace</h1>
+<h1 class="mb-3">Workspace</h1>
+
+<table id="events-table" class="table table-striped table-bordered w-100">
+  <thead>
+    <tr>
+      <th>Event ID</th>
+      <th>Title</th>
+      <th>Summary</th>
+      <th>Status</th>
+      <th>Severity</th>
+      <th>First Seen</th>
+      <th>Last Seen</th>
+      <th>Created At</th>
+      <th>Updated At</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
+
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
+<script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+<script src="/js/session.js"></script>
+<script src="/js/workspace-events.js"></script>

--- a/views/workspace.handlebars
+++ b/views/workspace.handlebars
@@ -18,6 +18,6 @@
 </table>
 
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
-<script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
-<script src="/js/session.js"></script>
-<script src="/js/workspace-events.js"></script>
+<script defer src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+<script defer src="/js/session.js"></script>
+<script defer src="/js/workspace-events.js"></script>

--- a/views/workspace.handlebars
+++ b/views/workspace.handlebars
@@ -17,7 +17,7 @@
   <tbody></tbody>
 </table>
 
-<link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
-<script defer src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+<link rel="stylesheet" href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.min.css">
+<script defer src="https://cdn.datatables.net/2.0.8/js/dataTables.min.js"></script>
 <script defer src="/js/session.js"></script>
 <script defer src="/js/workspace-events.js"></script>


### PR DESCRIPTION
### Motivation
- Introduce a concrete Event abstraction for session UI so events are represented as objects with a stable schema and can be edited and listed consistently. 
- Provide an interactive 3D view that maps those Event objects to graphical nodes and supports edit/delete interactions. 
- Surface the same session events in a tabular workspace view for easier inspection and sorting.

### Description
- Add `public/js/session.js` which defines a `SessionEvent` class and a sample `window.sessionEvents` array containing events with `event_id`, `title`, `summary`, `description`, `status`, `first_seen`, `last_seen`, `created_at`, `updated_at`, and `severity` fields. 
- Add `public/js/home-events.js` which renders a Three.js scene of event nodes, wires scroll-to-zoom, double-click to open an edit dialog, right-click to delete, and updates the in-memory `window.sessionEvents` array on save. 
- Add `public/js/workspace-events.js` which populates `views/workspace.handlebars` table from `window.sessionEvents` and initializes a DataTable for paging/sorting. 
- Update `views/home.handlebars` to include a richer event detail modal (all requested fields) and load `three.js`, `session.js`, and `home-events.js`. 
- Update `views/workspace.handlebars` to include the events table skeleton and DataTables assets and to load `session.js` and `workspace-events.js`.

### Testing
- Ran `npm test` which failed in this environment due to missing `nyc` (`sh: 1: nyc: not found`).
- Ran `npm run build` which failed in this environment due to missing `rimraf` (`sh: 1: rimraf: not found`).
- Ran `npm install` which failed in this environment with a registry error (`403 Forbidden` when fetching `nyc`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddfb05730c833282289d27b2e71b52)